### PR TITLE
Add Cabal 3.10.1.0 and GHC 9.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        cabal: ["3.2.0.0", "3.4.0.0"]
-        ghc: ["8.6.5", "8.8.3", "8.10.5", "9.0.1"]
+        cabal: ["3.2.0.0", "3.4.0.0", "3.10.1.0"]
+        ghc: ["8.6.5", "8.8.3", "8.10.5", "9.0.1", "9.6.2"]
         os: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,13 +1,18 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP #-}
 
 module Main (main) where
 
 import Control.Monad (unless, when)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+#if !MIN_VERSION_Cabal(3,10,0)
 import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
+#else
+import Distribution.Simple.PackageDescription (readGenericPackageDescription)
+#endif
 import Distribution.PackageDescription.PrettyPrint (showGenericPackageDescription)
 import Distribution.Simple.Utils (findPackageDesc)
 import Distribution.Uusi.Core

--- a/uusi.cabal
+++ b/uusi.cabal
@@ -25,6 +25,7 @@ tested-with:
    || ==8.8.3
    || ==8.10.5
    || ==9.0.1
+   || ==9.6.2
 
 source-repository head
   type:     git
@@ -33,7 +34,7 @@ source-repository head
 common common-options
   build-depends:
     , base   >=4.8 && <5
-    , Cabal  ^>=3.2 || ^>=3.4
+    , Cabal  ^>=3.2 || ^>=3.4 || ^>=3.10
     , text
 
   ghc-options:


### PR DESCRIPTION
Hi @berberman,
with Cabal 3.10.1.0, `readGenericPackageDescription` is moved to `Distribution.Simple.PackageDescription`, leading to import errors.
This change is necessary to get `uusi` running with GHC 9.6.2 on Arch.

Closes #7 