### PR TITLE
Update supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         cabal: ["3.4.0.0", "3.8.1.0", "3.10.1.0"]
-        ghc: ["9.0.2", "9.2.8", "9.4.7", "9.6.2"]
+        ghc: ["9.0.2", "9.2.8", "9.4.7", "9.6.2", "9.8.1"]
         os: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,7 @@ module Main (main) where
 import Control.Monad (unless, when)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-#if !MIN_VERSION_Cabal(3,6,0)
+#if !MIN_VERSION_Cabal(3,8,0)
 import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
 #else
 import Distribution.Simple.PackageDescription (readGenericPackageDescription)

--- a/uusi.cabal
+++ b/uusi.cabal
@@ -21,11 +21,11 @@ extra-doc-files:
   README.md
 
 tested-with:
-  GHC ==8.6.5
-   || ==8.8.3
-   || ==8.10.5
-   || ==9.0.1
+  GHC ==9.0.2
+   || ==9.2.8
+   || ==9.4.7
    || ==9.6.2
+   || ==9.8.1
 
 source-repository head
   type:     git
@@ -34,7 +34,7 @@ source-repository head
 common common-options
   build-depends:
     , base   >=4.8 && <5
-    , Cabal  ^>=3.2 || ^>=3.4 || ==3.6.3 || ^>= 3.8 || ^>= 3.10
+    , Cabal  ^>=3.2 || ^>=3.4 || ^>=3.6 || ^>= 3.8 || ^>= 3.10
     , text
 
   ghc-options:


### PR DESCRIPTION
@berberman 
- Add support for GHC 9.8. 9.8 uses Cabal 3.10.2.0 which is a [strict bug fix release](https://github.com/haskell/cabal/blob/master/release-notes/Cabal-3.10.2.0.md).
- Fully support Cabal 3.6.

Also updated `tested-with`.
Both `Cabal 3.6.3.0` and `Cabal 3.10.2.0` are not available on GHCup. While I've tested the former myself (with 9.2.8), the latter is a bugfix release with no changes expected.

Support for Cabal 3.6.3 was incomplete, so please make a new release on Hackage once this is merged.