### PR TITLE
Add `uusi-extract` to print the name and version of a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ If no option is specified, `uusi` will use `--all`, removing all version constra
 
 `uusi` provides an executable `gen-setup` to generate a boilerplate `Setup.hs`.
 
+Another executable, `uusi-extract`, prints out package information like the version or package name.
+
 ### Examples
 
 * Set all dependencies' version ranges to any version:
@@ -114,6 +116,20 @@ $ uusi --add-options-all -dynamic foo.cabal
 
 ```
 $ uusi --remove-options-all -Wall,-dynamic 
+```
+
+#### uusi-extract
+
+* print package version:
+
+```
+$ uusi-extract --print-version
+```
+
+* print package name:
+
+```
+$ uusi-extract --print-name
 ```
 
 ## Contributing

--- a/hie.yaml
+++ b/hie.yaml
@@ -8,3 +8,5 @@ cradle:
       component: "lib:uusi"
     - path: "./test"
       component: "test:uusi-tests"
+    - path: "./uusi-extract"
+      component: "exe:uusi-extract"

--- a/uusi-extract/Main.hs
+++ b/uusi-extract/Main.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP #-}
+#if MIN_VERSION_Cabal(3,14,0)
+{-# LANGUAGE DataKinds #-}
+#endif
+
+module Main (main) where
+
+import Data.Maybe (catMaybes)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+#if !MIN_VERSION_Cabal(3,8,0)
+import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
+#else
+import Distribution.Simple.PackageDescription (readGenericPackageDescription)
+#endif
+import Distribution.Simple.Utils (findPackageDesc)
+import Distribution.Types.GenericPackageDescription (GenericPackageDescription)
+#if MIN_VERSION_Cabal(3,14,0)
+import Distribution.Utils.Path (FileOrDir( File ), Pkg, SymbolicPath,
+                                makeSymbolicPath, relativeSymbolicPath)
+#endif
+import Distribution.Uusi.Utils ((<|))
+import qualified Distribution.Verbosity as Verbosity
+import Options
+import System.Environment (getArgs)
+
+-----------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+  args <- getArgs
+  (o, targets) <- runOption args
+
+  target <- case targets of
+#if !MIN_VERSION_Cabal(3,14,0)
+    [x] -> pure x
+#else
+    [x] -> pure (makeSymbolicPath x)
+#endif
+    [] -> findCabal
+    _ -> fail "Please specify at most one target to uusi-extract"
+
+  extractAction <- case catMaybes (joinOptions o) of
+    [x] -> pure x
+    [] -> fail "Please specify an action to uusi-extract"
+    _ -> fail "Please specify at most one action to uusi-extract"
+
+  uusiExtractCabal extractAction target
+
+-----------------------------------------------------------------------------
+
+#if !MIN_VERSION_Cabal(3,14,0)
+uusiExtractCabal :: (GenericPackageDescription -> T.Text) -> FilePath -> IO ()
+uusiExtractCabal extractAction originPath = do
+  cabal <- readGenericPackageDescription Verbosity.normal originPath
+  T.putStrLn <| extractAction cabal
+#else
+uusiExtractCabal :: (GenericPackageDescription -> T.Text) -> SymbolicPath Pkg 'File -> IO ()
+uusiExtractCabal extractAction originPath = do
+  cabal <- readGenericPackageDescription Verbosity.normal Nothing originPath
+  T.putStrLn <| extractAction cabal
+#endif
+
+#if !MIN_VERSION_Cabal(3,14,0)
+findCabal :: IO FilePath
+findCabal =
+  findPackageDesc "." >>= \case
+    Left err -> fail $ show err
+    Right x -> pure x
+#else
+findCabal :: IO (SymbolicPath Pkg 'File)
+findCabal =
+  findPackageDesc (Just (makeSymbolicPath ".")) >>= \case
+    Left err -> fail $ show err
+    Right x -> pure $ relativeSymbolicPath x
+#endif

--- a/uusi-extract/Options.hs
+++ b/uusi-extract/Options.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Options
+  ( Options (..),
+    runOption,
+    joinOptions,
+  )
+where
+
+import qualified Data.Text as T
+import Distribution.Pretty (pretty)
+import Distribution.Types.GenericPackageDescription (GenericPackageDescription, packageDescription)
+import Distribution.Types.PackageDescription (package)
+import Distribution.Types.PackageId (pkgVersion, pkgName)
+import Distribution.Uusi.Utils (chain, (<|))
+import System.Console.GetOpt
+import Text.PrettyPrint (Mode (LeftMode), Style (..), renderStyle)
+
+data Options = Options
+  { optVersion :: Maybe (GenericPackageDescription -> T.Text),
+    optName :: Maybe (GenericPackageDescription -> T.Text)
+  }
+
+style :: Style
+style = Style { lineLength = 100, ribbonsPerLine = 1.0, mode = LeftMode }
+
+defaultOptions :: Options
+defaultOptions = Options Nothing Nothing
+
+joinOptions :: Options -> [Maybe (GenericPackageDescription -> T.Text)]
+joinOptions Options {..} = [optVersion] <> [optName]
+
+cliOptions :: [OptDescr (Options -> Options)]
+cliOptions =
+  [ Option
+      []
+      ["print-version"]
+      (NoArg (\opts -> opts {optVersion = Just (\desc -> T.pack (renderStyle style (pretty (pkgVersion (package (packageDescription desc))))))}))
+      "print package version, e.g. --print-version",
+    Option
+      []
+      ["print-name"]
+      (NoArg (\opts -> opts {optName = Just (\desc -> T.pack (renderStyle style (pretty (pkgName (package (packageDescription desc))))))}))
+      "print package name, e.g. --print-name"
+  ]
+
+runOption :: [String] -> IO (Options, [FilePath])
+runOption argv = case getOpt Permute cliOptions argv of
+  (o, n, []) -> return (chain o <| defaultOptions, n)
+  (_, _, err) -> ioError <| userError <| concat err <> usageInfo help cliOptions
+  where
+    help = "uusi-extract - extract .cabal package information | usage: uusi-extract [OPTIONS] [TARGET] | find cabal file in cwd if target is not set"

--- a/uusi.cabal
+++ b/uusi.cabal
@@ -72,6 +72,17 @@ executable gen-setup
 
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
 
+executable uusi-extract
+  import:         common-options
+  hs-source-dirs: uusi-extract
+  main-is:        Main.hs
+  other-modules:  Options
+  build-depends:
+    , pretty
+    , uusi
+
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+
 test-suite uusi-tests
   import:         common-options
   hs-source-dirs: test


### PR DESCRIPTION
The `uusi-extract` command reads in the `.cabal` file and prints out the version or package name, depending on the chosen command line option.

This provides a better way to programmatically get the package name or the version of a package, so that in particular whitespace doesn't matter. The intended use case for this is Arch Linux's `ghc` package, where the library information needs to be extracted from the included `.cabal` files.

The actions are distinguished via two options which map to functions in the `Options` class. If an option is set, the corresponding function is added to the returned list. If that list contains no functions or more than one, an appropriate error is raised.
The functions take in the `GenericPackageDescription` that's the same for everything, and return the extracted `Text` for printing.

The implementation has been tested with up to 9.14 and includes CPP where necessary.

Solves #12 
Depends on #13 for the CI